### PR TITLE
Completely remove the need for /proc filesytem and iproute2.

### DIFF
--- a/butterfly/routes.py
+++ b/butterfly/routes.py
@@ -208,8 +208,8 @@ class TermWebSocket(Route, tornado.websocket.WebSocketHandler):
                     if field[0][0] == 'commonName':
                         self.user = self.callee = field[0][1]
 
-        if self.socket.local and self.socket.uid is not None:
-            self.caller = utils.User(uid=self.socket.uid)
+        if self.socket.local and self.socket.user is not None:
+            self.caller = utils.User(name=self.socket.user)
         else:
             # We don't know uid is on the other machine
             pass


### PR DESCRIPTION
This commit uses lsof, which is available in Linux, OSX,
and other BSD variants. Auto-logins should fail to a
login prompt with this patch when run under cygwin.
