### PR TITLE
Argument to turn login screen off (--host=0.0.0.0 --unsecure --login=False)

### DIFF
--- a/butterfly.server.py
+++ b/butterfly.server.py
@@ -37,6 +37,8 @@ tornado.options.define("port", default=57575, type=int, help="Server port")
 tornado.options.define("shell", help="Shell to execute at login")
 tornado.options.define("unsecure", default=False,
                        help="Don't use ssl not recommended")
+tornado.options.define("login", default=True,
+                       help="Use login screen at start")
 
 tornado.options.define("generate_certs", default=False,
                        help="Generate butterfly certificates")


### PR DESCRIPTION
Hello, we need this feature on rosti.cz. I will be pleased, if you accept my push request. We are planning to implement our own secure policy before butterfly instance and login screen was blocker. Thank you :-)
