### PR TITLE
Ability to run any command instead of shell using --cmd parameter

### DIFF
--- a/butterfly.server.py
+++ b/butterfly.server.py
@@ -36,6 +36,7 @@ tornado.options.define("more", default=False,
 tornado.options.define("host", default='localhost', help="Server host")
 tornado.options.define("port", default=57575, type=int, help="Server port")
 tornado.options.define("shell", help="Shell to execute at login")
+tornado.options.define("cmd", help="Command to run instead of shell")
 tornado.options.define("unsecure", default=False,
                        help="Don't use ssl not recommended")
 tornado.options.define("login", default=True,

--- a/butterfly/routes.py
+++ b/butterfly/routes.py
@@ -191,8 +191,12 @@ class TermWebSocket(Route, tornado.websocket.WebSocketHandler):
                           'if you want to log as different user\n')
                     sys.exit(1)
 
-            args = [tornado.options.options.shell or self.callee.shell]
-            args.append('-i')
+            args = [
+                tornado.options.options.cmd
+                or tornado.options.options.shell or self.callee.shell
+            ]
+            if not tornado.options.options.cmd:
+                args.append('-i')
             os.execvpe(args[0], args, env)
             # This process has been replaced
 


### PR DESCRIPTION
using --shell adds `-i` parameter and it is good, so I have added separated --cmd to pass any other program
f.i.
- butterfly.server.py --unsecure --cmd=/bin/ls
