### PR TITLE
Add Docker file container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ RUN python setup.py install
 ADD docker/run.sh /opt/run.sh
 RUN chmod 777 /opt/run.sh
 
-CMD ["docker/run.sh"]
+CMD ["/opt/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,6 @@ RUN python setup.py install
 ADD docker/run.sh /opt/run.sh
 RUN chmod 777 /opt/run.sh
 
+EXPOSE 57575
+
 CMD ["/opt/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,7 @@ WORKDIR /opt/app
 RUN python setup.py build
 RUN python setup.py install
 
+ADD docker/run.sh /opt/run.sh
+RUN chmod 777 /opt/run.sh
+
 CMD ["docker/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:14.04.1
+
+RUN apt-get update -y
+RUN apt-get install -y python-setuptools python-dev build-essential libffi-dev libssl-dev
+
+WORKDIR /opt
+ADD . /opt/app
+WORKDIR /opt/app
+
+RUN python setup.py build
+RUN python setup.py install
+
+CMD ["docker/run.sh"]

--- a/README.md
+++ b/README.md
@@ -67,3 +67,16 @@ Run `python dev.py --debug --port=12345` and you are set (yes you can launch it 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ```
+
+## Docker Usage
+There is a docker repository created for this project that is set to automatically rebuild when there is a push
+into this repository: https://registry.hub.docker.com/u/garland/butterfly/
+
+### Starting
+
+        docker run \
+        --env PASSWORD=password \
+        --env PORT=57575 \
+        -p 57575:57575 \
+        -d garland/butterfly
+

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 # Set password
-echo 'root:${PASSWORD}' | chpasswd
+echo "root:${PASSWORD}" | chpasswd
 
-./butterfly.server.py --unsecure --host=0.0.0.0
+/opt/app/butterfly.server.py --unsecure --host=0.0.0.0

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -3,4 +3,11 @@
 # Set password
 echo "root:${PASSWORD}" | chpasswd
 
-/opt/app/butterfly.server.py --unsecure --host=0.0.0.0
+if [ -z ${PORT} ]
+then
+  echo "Starting on default port: 57575"
+  /opt/app/butterfly.server.py --unsecure --host=0.0.0.0
+else
+  echo "Starting on port: ${PORT}"
+  /opt/app/butterfly.server.py --unsecure --host=0.0.0.0 --port=${PORT}
+fi

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Set password
+echo 'root:${PASSWORD}' | chpasswd
+
+./butterfly.server.py --unsecure --host=0.0.0.0


### PR DESCRIPTION
Adds in a Dockerfile to build this project into a container automatically on every push.  Since a lot of people are using Docker now, this makes it very easy to test this project out by just issuing one command on a Docker server which will have this project running and a base container for anyone that wants to extend this project to use.