### PR TITLE
Disable margin collapsing when inserting inline-html

### DIFF
--- a/coffees/term.coffee
+++ b/coffees/term.coffee
@@ -794,22 +794,25 @@ class Terminal
 
               # Disabling this for now as we need a good script
               #  striper to avoid malicious script injection
-              # when 99
-              #     # Custom escape to produce raw html
-              #     html = "<div class=\"inline-html\">" + @params[1] + "</div>"
-              #     @lines[@y + @ybase][@x] = [
-              #         @curAttr
-              #         html
-              #     ]
-              #     line = 0
+              #when 99
+              #  # Custom escape to produce raw html
+              #  # Prevent collapsing margin between parent and child elements with `overflow:auto`
+              #  # http://stackoverflow.com/questions/19718634/how-to-disable-margin-collapsing
+              #  html = "<div style=\"overflow: auto;\" " +
+              #         "class=\"inline-html\">" + @params[1] + "</div>"
+              #  @lines[@y + @ybase][@x] = [
+              #    @curAttr
+              #    html
+              #  ]
+              #  line = 0
 
-              #     while line < @get_html_height_in_lines(html) - 1
-              #         @y++
-              #         if @y > @scrollBottom
-              #             @y--
-              #             @scroll()
-              #         line++
-              #     @updateRange @y
+              #  while line < @get_html_height_in_lines(html) - 1
+              #    @y++
+              #    if @y > @scrollBottom
+              #      @y--
+              #      @scroll()
+              #    line++
+              #  @updateRange @y
 
             # reset colors
             @params = []


### PR DESCRIPTION
Hi Florian,

inline-html is still disabled, but when you enable it, margin collapsing should work properly now. See the two screens for comparison:

Before
=====

![screen shot 2015-04-07 at 21 29 28](https://cloud.githubusercontent.com/assets/1733229/7031858/d9cf964c-dd6e-11e4-8c37-a5d16d4527d1.png)




After
=====
![screen shot 2015-04-07 at 21 39 40](https://cloud.githubusercontent.com/assets/1733229/7031822/a96654d2-dd6e-11e4-9dcf-ce774f36cf30.png)
