### PR TITLE
Force all characters to be the same width

### DIFF
--- a/coffees/term.coffee
+++ b/coffees/term.coffee
@@ -399,14 +399,24 @@ class Terminal
 
       attr = @defAttr
       i = 0
+      spanIndex = null
+      spanLength = 0
       while i < line.length
         data = line[i][0]
         ch = line[i][1]
         if data isnt attr
-          out += "</span>" if attr isnt @defAttr
+          if attr isnt @defAttr
+            if spanIndex?
+              lhs = out.substring(0, spanIndex)
+              rhs = out.substring(spanIndex)
+              out = lhs + "style=\"display: inline-block; width: " + \
+                    (spanLength * @char_size.width) + "px;\" " + rhs
+            out += "</span>"
           if data isnt @defAttr
             classes = []
             out += "<span "
+            spanLength = 0
+            spanIndex = out.length
             bg = data & 0x1ff
             fg = (data >> 9) & 0x1ff
             flags = data >> 18
@@ -451,10 +461,12 @@ class Terminal
                 out += "&nbsp;"
               else
                 i++ if "\uff00" < ch < "\uffef"
+                spanLength++ if "\uff00" < ch < "\uffef"
                 out += ch
         out += "</span>" if i is x
         attr = data
         i++
+        spanLength++
       out += "</span>" if attr isnt @defAttr
       @children[y].innerHTML = out
       y++
@@ -1005,7 +1017,6 @@ class Terminal
             when "p"
               if @prefix is '!'
                 @softReset @params
-
             else
               console.error "Unknown CSI code: %s.", ch
           @prefix = ""


### PR DESCRIPTION
The terminals character width is not equal for all characters even if it's using a monospace font.

E.g. The BLACK RIGHT-POINTING SMALL TRIANGLE UNICODE character U+25B8 ▸ is displayed with 9px in my terminal, whereas most are rendered with 10px. This can lead to some layout artifacts. See the two screens for comparison of butterfly with below patch applied and without.

![before](https://cloud.githubusercontent.com/assets/1733229/7084532/8cbcbcc0-df6e-11e4-8ed7-cd11b8796558.jpg)
![after](https://cloud.githubusercontent.com/assets/1733229/7084534/9177428a-df6e-11e4-9069-f61d6cad1810.png)
