### PR TITLE
fixed shutil.get_terminal_size error

### DIFF
--- a/butterfly/bin/help.py
+++ b/butterfly/bin/help.py
@@ -4,6 +4,7 @@ from butterfly.utils import ansi_colors
 import os
 import base64
 import shutil
+import subprocess
 
 print(ansi_colors.white + "Welcome to the butterfly help." + ansi_colors.reset)
 path = os.getenv('BUTTERFLY_PATH')
@@ -56,7 +57,7 @@ Butterfly is a xterm compliant terminal built with python and javascript.
     code=ansi_colors.light_yellow,
     comment=ansi_colors.light_magenta,
     reset=ansi_colors.reset,
-    rcol=shutil.get_terminal_size()[0] - 31,
+    rcol=int(subprocess.check_output(['stty','size']).split()[1]) - 31,
     main=os.path.normpath(os.path.join(
                 os.path.abspath(os.path.dirname(__file__)),
                 '../sass/'))))


### PR DESCRIPTION
shutil.get_terminal_size is only available for python 3.3+
utilizing stty command is more universal. 