### PR TITLE
Fix for PATH that contains dot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,8 @@
-FROM ubuntu:14.04.1
+from python:3.5-onbuild
 
-RUN apt-get update -y
-RUN apt-get install -y python-setuptools python-dev build-essential libffi-dev libssl-dev
+run python setup.py build
+run python setup.py install
 
-WORKDIR /opt
-ADD . /opt/app
-WORKDIR /opt/app
+expose 57575
 
-RUN python setup.py build
-RUN python setup.py install
-
-ADD docker/run.sh /opt/run.sh
-RUN chmod 777 /opt/run.sh
-
-EXPOSE 57575
-
-CMD ["/opt/run.sh"]
+cmd ["/usr/src/app/docker/run.sh"]

--- a/butterfly/terminal.py
+++ b/butterfly/terminal.py
@@ -213,7 +213,7 @@ class Terminal(object):
                 args = tornado.options.options.cmd.split(' ')
             else:
                 args = [tornado.options.options.shell or self.callee.shell]
-                args.append('-i')
+                args.append('-il')
 
             # In some cases some shells don't export SHELL var
             env['SHELL'] = args[0]

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -6,8 +6,8 @@ echo "root:${PASSWORD}" | chpasswd
 if [ -z ${PORT} ]
 then
   echo "Starting on default port: 57575"
-  /opt/app/butterfly.server.py --unsecure --host=0.0.0.0
+  /usr/src/app/butterfly.server.py --unsecure --host=0.0.0.0
 else
   echo "Starting on port: ${PORT}"
-  /opt/app/butterfly.server.py --unsecure --host=0.0.0.0 --port=${PORT}
+  /usr/src/app/butterfly.server.py --unsecure --host=0.0.0.0 --port=${PORT}
 fi


### PR DESCRIPTION
Fix #109 

I also took the liberty to fix a few other things, please check.

In my opinion there's a bug in python 2.7 and `os.execve`, which should not modify PATH but does.

See https://docs.python.org/2/library/os.html#os.execve

Basically, the `os.exec*p` version should modify the PATH, while the `os.exec*e` should not... but still does (the bug also happens with I use `os.execve` instead of `os.execvpe`). If I refactor by removing the env entirely (`os.execv(path, args)`) then it fixs the bug but we lose functionalities because `BUTTERFLY_HOME` is not set, etc.

My fix of explicitely setting `env['PATH']` is a workaround around this `os.execve` bug, but theorically the first commit should have fixed the problem.

I only tested the basic usage, please test the other scenarios for regressions.