### PR TITLE
Fix problem with ignoring --shell option in python2

### DIFF
--- a/butterfly/terminal.py
+++ b/butterfly/terminal.py
@@ -264,7 +264,7 @@ class Terminal(object):
             args = ['/bin/su']
 
         args.append('-l')
-        if sys.platform == 'linux' and tornado.options.options.shell:
+        if sys.platform.startswith('linux') and tornado.options.options.shell:
             args.append('-s')
             args.append(tornado.options.options.shell)
         args.append(self.callee.name)


### PR DESCRIPTION
At python2 sys.platform return "linux2". This behaviour prevents to process --shell option properly. Usage startwith is a recomended way to avoid problems with linux versions (see: https://docs.python.org/3/library/sys.html#sys.platform).