### PR TITLE
Preserve environment variables from the parent environment

### DIFF
--- a/butterfly/terminal.py
+++ b/butterfly/terminal.py
@@ -173,6 +173,8 @@ class Terminal(object):
         else:
             # May need more?
             env = {}
+
+        env = os.environ # preserve environment, useful with Docker
         env["TERM"] = "xterm-256color"
         env["COLORTERM"] = "butterfly"
         env["HOME"] = self.callee.dir
@@ -267,6 +269,7 @@ class Terminal(object):
         if sys.platform.startswith('linux') and tornado.options.options.shell:
             args.append('-s')
             args.append(tornado.options.options.shell)
+        args.append('--preserve-environment')
         args.append(self.callee.name)
         os.execvpe(args[0], args, env)
 


### PR DESCRIPTION
It is useful to set runtime configuration with environment variables in Docker. Butterfly by default discards any environment variables set by the parent environment.

This PR copies `env = os.environ` and keeps them by passing `--preserve-environment` to `/bin/su`. 

I did not test any other configurations than the one provided by `--unsecure`. This PR will probably break other configurations as-is. I am running Butterfly as a non-root user in Docker, without the ability to change the user. Access control is provided by a Nginx reverse proxy in the front.