### PR TITLE
updating setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update \
     libssl-dev \
     python-dev \
     python-setuptools \
+ && sudo easy_install pip \
+ && sudo pip install --upgrade setuptools \
  && apt-get clean \
  && rm -r /var/lib/apt/lists/*
 


### PR DESCRIPTION
The build was failing with:

`Installed /tmp/easy_install-Q_wyGH/cryptography-2.1.4/pycparser-2.18-py2.7.egg

[91merror: Setup script exited with error in cryptography setup command: Invalid environment marker: python_version < '3'
[0m
Removing intermediate container d00caeed0cab

The command '/bin/sh -c python setup.py build  && python setup.py install' returned a non-zero code: 1`

I noticed if I updated the version of setuptools, the build would pass again. :)