### PR TITLE
added missing keepalive_timer.start()

### DIFF
--- a/butterfly/routes.py
+++ b/butterfly/routes.py
@@ -139,6 +139,7 @@ class KeptAliveWebSocketHandler(tornado.websocket.WebSocketHandler):
     def open(self, *args, **kwargs):
         self.keepalive_timer = tornado.ioloop.PeriodicCallback(
             self.send_ping, tornado.options.options.keepalive_interval * 1000)
+        self.keepalive_timer.start()
 
     def send_ping(self):
         t = int(time.time())


### PR DESCRIPTION
Currently, the keepalive ping is not started and thus causes the connection to be closed under some circumstances (e.g. CloudFlare drops ws connections after 100s without ping). May solve #167 for some people.