### PR TITLE
Allow arguments to --cmd to contain tabs or multiple spaces

### DIFF
--- a/butterfly/terminal.py
+++ b/butterfly/terminal.py
@@ -224,7 +224,7 @@ class Terminal(object):
                     sys.exit(1)
 
             if tornado.options.options.cmd:
-                args = tornado.options.options.cmd.split(' ')
+                args = tornado.options.options.cmd.split()
             else:
                 args = [tornado.options.options.shell or self.callee.shell]
                 args.append('-il')


### PR DESCRIPTION
What do you think of allowing split to separate the --cmd argument on any white space instead of specifically one space?

After a few days of fighting with the following command line syntax:

butterfly.server.py --host=0.0.0.0 --port=57575 --cmd='/usr/bin/docker run --rm -it --mount type=bind,source=/home/mark/app,target=/app,readonly  myimage /bin/bash' 

I was able to determine that it was breaking because I had more than one space between "readonly" and "myimage".   This syntax works just fine:

butterfly.server.py --host=0.0.0.0 --port=57575 --cmd='/usr/bin/docker run --rm -it --mount type=bind,source=/home/mark/app,target=/app,readonly myimage /bin/bash'

Such a subtle difference is easily unnoticed by the user.
