### PR TITLE
Added username, client_cert_required options

### DIFF
--- a/butterfly.server.py
+++ b/butterfly.server.py
@@ -84,6 +84,10 @@ tornado.options.define("generate_user_pkcs", default='',
 tornado.options.define("uri_root_path", default='',
                        help="Sets the servier root path: "
                        "example.com/<uri_root_path>/static/")
+tornado.options.define("username", default=None,
+                       help="The username to use for shell")
+tornado.options.define("client_cert_required", default=True,
+                       help="Require client to present a certificate")
 
 
 if os.getuid() == 0:
@@ -346,8 +350,10 @@ else:
         'certfile': cert % host,
         'keyfile': cert_key % host,
         'ca_certs': ca,
-        'cert_reqs': ssl.CERT_REQUIRED
     }
+    if options.client_cert_required:
+        ssl_opts['cert_reqs'] = ssl.CERT_REQUIRED
+
     if options.ssl_version is not None:
         if not hasattr(
                 ssl, 'PROTOCOL_%s' % options.ssl_version):

--- a/butterfly/routes.py
+++ b/butterfly/routes.py
@@ -174,9 +174,12 @@ class TermCtlWebSocket(Route, KeptAliveWebSocketHandler):
             'path', [b''])[0].decode('utf-8')
         secure_user = None
 
-        if not tornado.options.options.unsecure:
+        if tornado.options.options.username is not None:
+            user = utils.User(name=user)
+        elif not tornado.options.options.unsecure:
             user = utils.parse_cert(
                 self.ws_connection.stream.socket.getpeercert())
+
             assert user, 'No user in certificate'
             try:
                 user = utils.User(name=user)


### PR DESCRIPTION
Added --username option to specify user on command line,
and --client_cert_required option to allow https without requiring the
client to provide a cert.

When --username is defined, --client_cert_required is False, and
--login is False, then a shell will be offered without any
authentication.  Because of this, --login=True is recommended.