### PR TITLE
Uri root path issues for themes and sessions.

### DIFF
--- a/coffees/ext/sessions.coffee
+++ b/coffees/ext/sessions.coffee
@@ -12,7 +12,8 @@ document.addEventListener 'keydown', (e) ->
     else
       out += '<ul>'
       for session in response.sessions
-        out += "<li><a href=\"{_root_path}/session/#{session}\">#{session}</a></li>"
+        path = "{_root_path}/session/#{session}"
+        out += "<li><a href=\"{path}\">#{session}</a></li>"
       out += '</ul>'
 
     out += '</div>'

--- a/coffees/ext/sessions.coffee
+++ b/coffees/ext/sessions.coffee
@@ -1,3 +1,5 @@
+_root_path = document.body.getAttribute('data-root-path')
+
 document.addEventListener 'keydown', (e) ->
   return true unless e.altKey and e.keyCode is 69
   oReq = new XMLHttpRequest()
@@ -10,13 +12,13 @@ document.addEventListener 'keydown', (e) ->
     else
       out += '<ul>'
       for session in response.sessions
-        out += "<li><a href=\"/session/#{session}\">#{session}</a></li>"
+        out += "<li><a href=\"{_root_path}/session/#{session}\">#{session}</a></li>"
       out += '</ul>'
 
     out += '</div>'
 
     popup.open out
 
-  oReq.open("GET", "/sessions/list.json")
+  oReq.open("GET", _root_path + "/sessions/list.json")
   oReq.send()
   cancel e

--- a/coffees/ext/theme.coffee
+++ b/coffees/ext/theme.coffee
@@ -1,3 +1,5 @@
+_root_path = document.body.getAttribute('data-root-path')
+
 _set_theme_href = (href) ->
   document.getElementById('style').setAttribute('href', href)
   img = document.createElement('img')
@@ -48,18 +50,18 @@ document.addEventListener 'keydown', (e) ->
       inner += theme
       inner += '</option>'
 
-    option "/static/main.css", 'default'
+    option _root_path + "/static/main.css", 'default'
 
     if themes.length
       inner += '<optgroup label="Local themes">'
       for theme in themes
-        url = "/theme/#{theme}/style.css"
+        url = _root_path + "/theme/#{theme}/style.css"
         option url, theme
       inner += '</optgroup>'
 
     inner += '<optgroup label="Built-in themes">'
     for theme in builtin_themes
-      url = "/theme/#{theme}/style.css"
+      url = _root_path + "/theme/#{theme}/style.css"
       option url, theme.slice('built-in-'.length)
     inner += '</optgroup>'
 
@@ -74,7 +76,7 @@ document.addEventListener 'keydown', (e) ->
 
     theme_list.addEventListener 'change', -> set_theme theme_list.value
 
-  oReq.open("GET", "/themes/list.json")
+  oReq.open("GET", _root_path + "/themes/list.json")
   oReq.send()
 
   cancel e


### PR DESCRIPTION
Fixes:

* https://github.com/paradoxxxzero/butterfly/issues/190
* https://github.com/paradoxxxzero/butterfly/issues/195

That is, ensures that URL path supplied with ``--uri-root-path`` is added to front of URLs generated in response to ``<alt-s>`` (themes) and ``<alt-e>`` (sessions).