### PR TITLE
Fix pfx generation with pyOpenSSL >= 24.1.0

### DIFF
--- a/butterfly.server.py
+++ b/butterfly.server.py
@@ -278,7 +278,7 @@ if (options.generate_current_user_pkcs or
     from OpenSSL import crypto
     try:
         from OpenSSL.crypto import PKCS12
-        log.info("Using PKCS12 from OpenSSL.crypto
+        log.info("Using PKCS12 from OpenSSL.crypto")
     except:
         from cryptography.hazmat.primitives.serialization import pkcs12 as PKCS12
         from cryptography.hazmat.primitives.serialization import BestAvailableEncryption, NoEncryption

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     platforms="Any",
     scripts=['butterfly.server.py', 'scripts/butterfly', 'scripts/b'],
     packages=['butterfly'],
-    install_requires=["tornado>=3.2", "pyOpenSSL"],
+    install_requires=["tornado>=3.2", "pyOpenSSL", "cryptography"],
     extras_require={
         'themes': ["libsass"],
         'systemd': ['tornado_systemd'],


### PR DESCRIPTION
As of pyOpenSSL 24.1.0, the PKCS12 class is no longer available. Replace it with comparable PKCS12 from the cryptography package when importing fails, work around the changes.

See:	https://github.com/pyca/pyopenssl/blob/main/CHANGELOG.rst#2410-2024-03-09